### PR TITLE
Support both 14k and 16k pages to fix 32bit build on Raspberry Pi 5

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,9 @@ export PREFIX
 UNAME := $(shell uname)
 export UNAME
 
+# Support both 4K & 16K pages for Raspberry Pi 5
+LDFLAGS += "-Wl,-z,max-page-size=16384"
+
 all: 
 	@LDFLAGS="$(LDFLAGS)" CPPFLAGS="$(CPPFLAGS)" $(MAKE) -C $(top_srcdir)/cpp/build/ -$(MAKEFLAGS)
 	@LDFLAGS="$(LDFLAGS)" CPPFLAGS="$(CPPFLAGS)" $(MAKE) -C $(top_srcdir)/cpp/examples/MinOZW/ -$(MAKEFLAGS)


### PR DESCRIPTION
Designed to fix https://github.com/WebThingsIO/zwave-adapter/issues/146